### PR TITLE
don't use period when listing serial names

### DIFF
--- a/SerialGUI.py
+++ b/SerialGUI.py
@@ -160,7 +160,7 @@ class Dialog(QDialog):
         layout = QVBoxLayout()
 
         # Make dropdown
-        dropdownChoices = glob.glob("/dev/tty.*")[::-1]
+        dropdownChoices = glob.glob("/dev/tty*")[::-1]
         self.dd = QComboBox()
         self.dd.addItems(dropdownChoices)
         self.formGroupBox = QGroupBox("")


### PR DESCRIPTION
None of my serial ports have a period in the name. The presence of the period meant that the list was population with nothing.